### PR TITLE
Switch dependency from prefab-classes to ducktools-classbuilder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "ducktools-lazyimporter",
-    "prefab-classes",
+    "ducktools-classbuilder",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/src/ducktools/pythonfinder/__init__.py
+++ b/src/ducktools/pythonfinder/__init__.py
@@ -16,7 +16,7 @@
 
 # Find platform python versions
 
-__version__ = "v0.1.0"
+__version__ = "v0.1.1"
 
 __all__ = [
     "get_python_installs",

--- a/src/ducktools/pythonfinder/shared.py
+++ b/src/ducktools/pythonfinder/shared.py
@@ -18,7 +18,7 @@ import sys
 import os
 import os.path
 
-from prefab_classes import prefab, attribute
+from ducktools.classbuilder import slotclass, Field, SlotFields
 from ducktools.lazyimporter import LazyImporter, ModuleImport, FromImport
 
 from . import details_script
@@ -37,13 +37,20 @@ _laz = LazyImporter(
 FULL_PY_VER_RE = r"(?P<major>\d+)\.(?P<minor>\d+)\.?(?P<micro>\d*)(?P<releaselevel>[a-zA-Z]*)(?P<serial>\d*)"
 
 
-@prefab
+@slotclass
 class PythonInstall:
+    __slots__ = SlotFields(
+        version=Field(),
+        executable=Field(),
+        architecture="64bit",
+        implementation="cpython",
+        metadata=Field(default_factory=dict),
+    )
     version: tuple[int, int, int, str, int]
     executable: str
-    architecture: str = "64bit"
-    implementation: str = "cpython"
-    metadata: dict = attribute(default_factory=dict)
+    architecture: str
+    implementation: str
+    metadata: dict
 
     @property
     def version_str(self) -> str:


### PR DESCRIPTION
Use the `@slotclass` from `ducktools.classbuilder` instead of `@prefab` from `prefab_classes`.

I'm deprecating `prefab_classes` as the code has now moved to classbuilder.