### PR TITLE
Use setuptools-scm to handle version numbers

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -29,11 +29,35 @@ jobs:
         name: python-package-distributions
         path: dist/
 
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/ducktools-pythonfinder
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
     needs:
-    - build
+    - publish-to-testpypi
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -29,35 +29,11 @@ jobs:
         name: python-package-distributions
         path: dist/
 
-  publish-to-testpypi:
-    name: Publish Python 🐍 distribution 📦 to TestPyPI
-    needs:
-    - build
-    runs-on: ubuntu-latest
-
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/ducktools-pythonfinder
-
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution 📦 to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
     needs:
-    - publish-to-testpypi
+    - build
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/publish_to_testpypi.yml
+++ b/.github/workflows/publish_to_testpypi.yml
@@ -1,6 +1,9 @@
 name: Test Publish Package to TestPyPi
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ cython_debug/
 
 # Scratch folder
 scratch/
+
+# Setuptools-scm version file
+_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "setuptools>=61.0",
-    "wheel",
+    "setuptools>=64",
+    "setuptools-scm>=8",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -41,8 +41,8 @@ testing = ["pytest", "pytest-cov", "pyfakefs"]
 [tool.setuptools.packages.find]
 where = ["src"]
 
-[tool.setuptools.dynamic]
-version = { attr = "ducktools.pythonfinder.__version__" }
+[tool.setuptools_scm]
+version_file = "src/ducktools/pythonfinder/_version.py"
 
 [tool.pytest.ini_options]
 addopts = "--cov=src/ --cov-report=term-missing --cov-report=xml:coverage.xml"

--- a/src/ducktools/pythonfinder/__init__.py
+++ b/src/ducktools/pythonfinder/__init__.py
@@ -23,8 +23,6 @@
 
 # Find platform python versions
 
-__version__ = "v0.2.0"
-
 __all__ = [
     "get_python_installs",
     "list_python_installs",
@@ -32,6 +30,7 @@ __all__ = [
 ]
 
 import sys
+from ._version import __version__
 from .shared import PythonInstall
 
 


### PR DESCRIPTION
Let setuptools-scm handle version numbers.

`publish-to-testpypi` will now happen on making a tag. `publish-to-pypi` on github release.