### PR TITLE
Add a console script entrypoint `ducktools-pythonfinder`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dynamic = ['version']
 [project.optional-dependencies]
 testing = ["pytest", "pytest-cov", "pyfakefs"]
 
+[project.scripts]
+"ducktools-pythonfinder" = "ducktools.pythonfinder.__main__:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 


### PR DESCRIPTION
This *should* make the package usable directly via uvx.