### PR TITLE
Include the implementation version in the command line search

### DIFF
--- a/src/ducktools/pythonfinder/details_script.py
+++ b/src/ducktools/pythonfinder/details_script.py
@@ -26,7 +26,7 @@ Get the details from a python install as JSON
 """
 import sys
 
-FULL_PY_VER_RE = r"(?P<major>\d+)\.(?P<minor>\d+)\.?(?P<micro>\d*)(?P<releaselevel>[a-zA-Z]*)(?P<serial>\d*)"
+FULL_PY_VER_RE = r"(?P<major>\d+)\.(?P<minor>\d+)\.?(?P<micro>\d*)-?(?P<releaselevel>[a-zA-Z]*)(?P<serial>\d*)"
 
 
 def version_str_to_tuple(version):
@@ -37,7 +37,7 @@ def version_str_to_tuple(version):
 
     major, minor, micro, releaselevel, serial = parsed_version.groups()
 
-    if releaselevel == "a":
+    if releaselevel in {"a", "dev"}:
         releaselevel = "alpha"
     elif releaselevel == "b":
         releaselevel = "beta"

--- a/src/ducktools/pythonfinder/shared.py
+++ b/src/ducktools/pythonfinder/shared.py
@@ -131,6 +131,7 @@ class PythonInstall(Prefab):
     implementation: str = "cpython"
     metadata: dict = attribute(default_factory=dict)
     shadowed: bool = False
+    _implementation_version: tuple[int, int, int, str, int] | None = attribute(default=None, private=True)
 
     def __prefab_post_init__(
         self,
@@ -146,6 +147,19 @@ class PythonInstall(Prefab):
     @property
     def version_str(self) -> str:
         return version_tuple_to_str(self.version)
+
+    @property
+    def implementation_version(self) -> tuple[int, int, int, str, int] | None:
+        if self._implementation_version is None:
+            if self.implementation == "cpython":
+                self._implementation_version = self.version
+            elif implementation_ver := self.metadata.get(f"{self.implementation}_version"):
+                self._implementation_version = implementation_ver
+        return self._implementation_version
+
+    @property
+    def implementation_version_str(self) -> str:
+        return version_tuple_to_str(self.implementation_version)
 
     @classmethod
     def from_str(
@@ -302,7 +316,7 @@ def _implementation_from_uv_dir(
             if query_executables:
                 install = get_install_details(python_path)
         else:
-            if implementation in {"cpython", "pypy"}:
+            if implementation in {"cpython"}:
                 install = PythonInstall.from_str(
                     version=version,
                     executable=python_path,

--- a/src/ducktools/pythonfinder/shared.py
+++ b/src/ducktools/pythonfinder/shared.py
@@ -259,7 +259,6 @@ def get_install_details(executable: str) -> PythonInstall | None:
     try:
         output = _laz.json.loads(detail_output)
     except _laz.json.JSONDecodeError as e:
-        print(e, f"{executable=}")
         return None
 
     return PythonInstall.from_json(**output)


### PR DESCRIPTION
Adds an attribute to store implementation version as the 5 part version_info tuple as you retrieve from `sys.implementation.version` (Except for MicroPython, which is special cased to handle a 3 part version).