### PR TITLE
Add a "Company" key to the registry search on windows

### DIFF
--- a/src/ducktools/pythonfinder/linux/__init__.py
+++ b/src/ducktools/pythonfinder/linux/__init__.py
@@ -34,7 +34,7 @@ from .pyenv_search import get_pyenv_pythons
 def get_path_pythons() -> Iterator[PythonInstall]:
     exe_names = set()
 
-    path_folders = os.environ.get("PATH").split(":")
+    path_folders = os.environ.get("PATH", "").split(":")
     pyenv_root = os.environ.get("PYENV_ROOT")
     uv_root = get_uv_python_path()
 

--- a/src/ducktools/pythonfinder/win32/registry_search.py
+++ b/src/ducktools/pythonfinder/win32/registry_search.py
@@ -74,7 +74,9 @@ def get_registered_pythons() -> Iterator[PythonInstall]:
                     continue
 
                 with winreg.OpenKey(base_key, company) as company_key:
-                    comp_metadata = {}
+                    comp_metadata = {
+                        "Company": company
+                    }
 
                     for name, data, _ in enum_values(company_key):
                         comp_metadata[f"Company{name}"] = data

--- a/src/ducktools/pythonfinder/win32/registry_search.py
+++ b/src/ducktools/pythonfinder/win32/registry_search.py
@@ -82,7 +82,10 @@ def get_registered_pythons() -> Iterator[PythonInstall]:
                         comp_metadata[f"Company{name}"] = data
 
                     for py_keyname in enum_keys(company_key):
-                        metadata = {**comp_metadata}
+                        metadata = {
+                            **comp_metadata,
+                            "Tag": py_keyname,
+                        }
 
                         with winreg.OpenKey(company_key, py_keyname) as py_key:
                             for name, data, _ in enum_values(py_key):


### PR DESCRIPTION
Keeps the 'company' key names in `medatada` of the PythonInstall.

This is needed to replicate the `py` launcher behaviour.
