### PR TITLE
Parent python executables might not have a 'python' alias

### DIFF
--- a/src/ducktools/pythonfinder/venv.py
+++ b/src/ducktools/pythonfinder/venv.py
@@ -105,7 +105,8 @@ class PythonVEnv(Prefab):
                 except _laz.subprocess.CalledProcessError:
                     pass
                 else:
-                    parent_exe = pyout.stdout.strip()
+                    if out_exe := pyout.stdout.strip():
+                        parent_exe = os.path.join(self.parent_path, os.path.basename(out_exe))
 
             self._parent_executable = parent_exe
 

--- a/src/ducktools/pythonfinder/venv.py
+++ b/src/ducktools/pythonfinder/venv.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 
-from ducktools.classbuilder.prefab import Prefab
+from ducktools.classbuilder.prefab import Prefab, attribute
 from ducktools.lazyimporter import LazyImporter, FromImport, ModuleImport
 
 from .shared import (
@@ -46,6 +46,7 @@ _laz = LazyImporter(
     [
         ModuleImport("re"),
         ModuleImport("json"),
+        ModuleImport("subprocess"),
         FromImport("pathlib", "Path"),
         FromImport("subprocess", "run"),
     ]
@@ -74,6 +75,7 @@ class PythonVEnv(Prefab):
     executable: str
     version: tuple[int, int, int, str, int]
     parent_path: str
+    _parent_executable: str | None = attribute(default=None, repr=False)
 
     @property
     def version_str(self) -> str:
@@ -81,10 +83,33 @@ class PythonVEnv(Prefab):
 
     @property
     def parent_executable(self) -> str:
-        if sys.platform == "win32":
-            return os.path.join(self.parent_path, "python.exe")
-        else:
-            return os.path.join(self.parent_path, "python")
+        if self._parent_executable is None:
+            # Guess the parent executable file
+            if sys.platform == "win32":
+                parent_exe = os.path.join(self.parent_path, "python.exe")
+            else:
+                parent_exe = os.path.join(self.parent_path, "python")
+
+            if not os.path.exists(parent_exe):
+                try:
+                    pyout = _laz.run(
+                        [
+                            self.executable,
+                            "-c",
+                            "from sysconfig import get_config_var; print(get_config_var('EXENAME'))",
+                        ],
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                    )
+                except _laz.subprocess.CalledProcessError:
+                    pass
+                else:
+                    parent_exe = pyout.stdout.strip()
+
+            self._parent_executable = parent_exe
+
+        return self._parent_executable
 
     @property
     def parent_exists(self) -> bool:
@@ -150,7 +175,7 @@ class PythonVEnv(Prefab):
         :param cfg_path: Path to a virtualenv config file
         :return: PythonVEnv with details relative to that config file
         """
-        parent_path, version_str = None, None
+        parent_path, version_str, parent_exe = None, None, None
         venv_base = os.path.dirname(cfg_path)
 
         with open(cfg_path, 'r') as f:
@@ -162,12 +187,15 @@ class PythonVEnv(Prefab):
                 elif key in {"version", "version_info"}:
                     # venv and uv use different key names :)
                     version_str = value
+                elif key == "executable":
+                    parent_exe = value
 
-                if parent_path and version_str:
+                if parent_path and version_str and parent_exe:
                     break
-            else:
-                # Not a valid venv, ignore
-                raise InvalidVEnvError(f"Path and version not defined in {cfg_path}")
+
+            if parent_path is None or version_str is None:
+                # Not a valid venv
+                raise InvalidVEnvError(f"Path or version not defined in {cfg_path}")
 
         if sys.platform == "win32":
             venv_exe = os.path.join(venv_base, "Scripts", "python.exe")
@@ -198,6 +226,7 @@ class PythonVEnv(Prefab):
             executable=venv_exe,
             version=version_tuple,
             parent_path=parent_path,
+            _parent_executable=parent_exe,
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import sys
+import sysconfig
 
 from pathlib import Path
 
@@ -42,12 +43,10 @@ def uses_details_script(fs):
 
 @pytest.fixture(scope="session")
 def this_python():
-    if sys.platform == "win32":
-        py_exe = Path(sys.base_prefix) / "python.exe"
-    else:
-        py_exe = Path(sys.base_prefix) / "bin" / "python"
-
-    return get_install_details(str(py_exe))
+    # Incorrect deprecation warning from PyCharm
+    # noinspection PyDeprecation
+    py_exe = sysconfig.get_config_var("EXENAME")
+    return get_install_details(py_exe)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import os.path
 import sys
 import sysconfig
 
@@ -43,10 +44,21 @@ def uses_details_script(fs):
 
 @pytest.fixture(scope="session")
 def this_python():
-    # Incorrect deprecation warning from PyCharm
-    # noinspection PyDeprecation
-    py_exe = sysconfig.get_config_var("EXENAME")
-    return get_install_details(py_exe)
+    config_exe = sysconfig.get_config_var("EXENAME")
+
+    if config_exe:
+        exename = os.path.basename(sysconfig.get_config_var("EXENAME"))
+    elif sys.platform == "win32":
+        exename = "python.exe"
+    else:
+        exename = "python"
+
+    if sys.platform == "win32":
+        py_exe = Path(sys.base_prefix) / exename
+    else:
+        py_exe = Path(sys.base_prefix) / "bin" / exename
+
+    return get_install_details(str(py_exe))
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_venv_finder.py
+++ b/tests/test_venv_finder.py
@@ -125,7 +125,7 @@ def test_found_parent(with_venvs, this_python, this_venv):
 
     # We found the base env that created this python, all details match
     parent = venv_ex.get_parent_install()
-    assert parent == this_python
+    assert os.path.dirname(parent.executable) == os.path.dirname(this_python.executable)
 
     # venv version str works same as parent
     assert venv_ex.version_str == parent.version_str


### PR DESCRIPTION
This was incorrectly assumed, but for instance some distros only provide python3 or python3.y aliases.

Now we check the venv config to see if it gives the Path, if not attempt to assume the 'python' alias is there. If it's not, try to launch the venv to ask.