### PR TITLE
Cache details of Python installs that are queried

### DIFF
--- a/src/ducktools/pythonfinder/__init__.py
+++ b/src/ducktools/pythonfinder/__init__.py
@@ -32,7 +32,7 @@ __all__ = [
 
 import sys
 from ._version import __version__
-from .shared import PythonInstall
+from .shared import PythonInstall, DetailFinder
 
 
 if sys.platform == "win32":
@@ -43,9 +43,10 @@ else:
     from .linux import get_python_installs
 
 
-def list_python_installs(*, query_executables=True):
+def list_python_installs(*, query_executables: bool = True, finder: DetailFinder | None = None):
+    finder = DetailFinder() if finder is None else finder
     return sorted(
-        get_python_installs(query_executables=query_executables),
+        get_python_installs(query_executables=query_executables, finder=finder),
         reverse=True,
         key=lambda x: (x.version[3], *x.version[:3], x.version[4])
     )

--- a/src/ducktools/pythonfinder/details_script.py
+++ b/src/ducktools/pythonfinder/details_script.py
@@ -29,11 +29,13 @@ import sys
 FULL_PY_VER_RE = r"(?P<major>\d+)\.(?P<minor>\d+)\.?(?P<micro>\d*)-?(?P<releaselevel>a|b|c|rc)?(?P<serial>\d*)?"
 
 
-def version_str_to_tuple(version):
+def version_str_to_tuple(version: str):
     # Needed to parse GraalPy versions only available as strings
     import re
 
     parsed_version = re.fullmatch(FULL_PY_VER_RE, version)
+    if parsed_version is None:
+        raise ValueError(f"'version' must be a valid Python version string, not {version!r}")
 
     major, minor, micro, releaselevel, serial = parsed_version.groups()
 
@@ -70,11 +72,11 @@ def get_details():
             # Special case GraalPy as it erroneously reports the CPython target
             # instead of the Graal versiion
             try:
-                ver = __graalpython__.get_graalvm_version()
+                ver = __graalpython__.get_graalvm_version()  # type: ignore
                 metadata = {
                     "graalpy_version": version_str_to_tuple(ver)
                 }
-            except NameError:
+            except (NameError, ValueError):
                 metadata = {"{}_version".format(implementation): sys.implementation.version}
         elif implementation != "cpython":  # pragma: no cover
             metadata = {"{}_version".format(implementation): sys.implementation.version}

--- a/src/ducktools/pythonfinder/linux/__init__.py
+++ b/src/ducktools/pythonfinder/linux/__init__.py
@@ -48,7 +48,6 @@ def get_path_pythons(*, finder: DetailFinder | None = None) -> Iterator[PythonIn
 
     finder = DetailFinder if finder is None else finder
 
-
     for fld in path_folders:
         # Don't retrieve pyenv installs
         skip_folder = False
@@ -88,7 +87,8 @@ def get_python_installs(
     if query_executables:
         chain_commands.append(get_path_pythons(finder=finder))
 
-    for py in itertools.chain.from_iterable(chain_commands):
-        if py.executable not in listed_pythons:
-            yield py
-            listed_pythons.add(py.executable)
+    with finder:
+        for py in itertools.chain.from_iterable(chain_commands):
+            if py.executable not in listed_pythons:
+                yield py
+                listed_pythons.add(py.executable)

--- a/src/ducktools/pythonfinder/linux/__init__.py
+++ b/src/ducktools/pythonfinder/linux/__init__.py
@@ -27,11 +27,17 @@ import os.path
 import itertools
 from _collections_abc import Iterator
 
-from ..shared import PythonInstall, get_folder_pythons, get_uv_pythons, get_uv_python_path
+from ..shared import (
+    DetailFinder,
+    PythonInstall,
+    get_folder_pythons,
+    get_uv_pythons,
+    get_uv_python_path
+)
 from .pyenv_search import get_pyenv_pythons, get_pyenv_root
 
 
-def get_path_pythons() -> Iterator[PythonInstall]:
+def get_path_pythons(*, finder: DetailFinder | None = None) -> Iterator[PythonInstall]:
     exe_names = set()
 
     path_folders = os.environ.get("PATH", "").split(":")
@@ -39,6 +45,9 @@ def get_path_pythons() -> Iterator[PythonInstall]:
     uv_root = get_uv_python_path()
 
     excluded_folders = [pyenv_root, uv_root]
+
+    finder = DetailFinder if finder is None else finder
+
 
     for fld in path_folders:
         # Don't retrieve pyenv installs
@@ -54,7 +63,7 @@ def get_path_pythons() -> Iterator[PythonInstall]:
         if not os.path.exists(fld):
             continue
 
-        for install in get_folder_pythons(fld):
+        for install in get_folder_pythons(fld, finder=finder):
             name = os.path.basename(install.executable)
             if name in exe_names:
                 install.shadowed = True
@@ -63,15 +72,21 @@ def get_path_pythons() -> Iterator[PythonInstall]:
             yield install
 
 
-def get_python_installs(*, query_executables=True):
+def get_python_installs(
+    *,
+    query_executables: bool = True,
+    finder: DetailFinder | None = None,
+) -> Iterator[PythonInstall]:
     listed_pythons = set()
 
+    finder = DetailFinder() if finder is None else finder
+
     chain_commands = [
-        get_pyenv_pythons(query_executables=query_executables),
-        get_uv_pythons(query_executables=query_executables),
+        get_pyenv_pythons(query_executables=query_executables, finder=finder),
+        get_uv_pythons(query_executables=query_executables, finder=finder),
     ]
     if query_executables:
-        chain_commands.append(get_path_pythons())
+        chain_commands.append(get_path_pythons(finder=finder))
 
     for py in itertools.chain.from_iterable(chain_commands):
         if py.executable not in listed_pythons:

--- a/src/ducktools/pythonfinder/linux/pyenv_search.py
+++ b/src/ducktools/pythonfinder/linux/pyenv_search.py
@@ -22,8 +22,6 @@
 # SOFTWARE.
 from __future__ import annotations
 
-from json import JSONDecodeError
-
 """
 Discover python installs that have been created with pyenv
 """
@@ -38,6 +36,7 @@ from ..shared import PythonInstall, DetailFinder, FULL_PY_VER_RE, INSTALLER_CACH
 
 _laz = LazyImporter(
     [
+        ModuleImport("json"),
         ModuleImport("re"),
         FromImport("subprocess", "run"),
     ]
@@ -55,7 +54,7 @@ def get_pyenv_root() -> str | None:
         try:
             with open(INSTALLER_CACHE_PATH) as f:
                 installer_cache = _laz.json.load(f)
-        except (FileNotFoundError, JSONDecodeError):
+        except (FileNotFoundError, _laz.json.JSONDecodeError):
             installer_cache = {}
 
         pyenv_root = installer_cache.get("pyenv")

--- a/src/ducktools/pythonfinder/shared.py
+++ b/src/ducktools/pythonfinder/shared.py
@@ -199,6 +199,8 @@ class DetailFinder(Prefab):
         with open(self.cache_path, 'w') as f:
             _laz.json.dump(self.raw_cache, f, indent=4)
 
+        self._dirty_cache = False
+
     def clear_invalid_runtimes(self):
         """
         Remove cache entries where the python.exe no longer exists

--- a/src/ducktools/pythonfinder/venv.py
+++ b/src/ducktools/pythonfinder/venv.py
@@ -144,8 +144,8 @@ class PythonVEnv(Prefab):
                     break
 
             if install is None:
-                install = finder.get_install_details(exe)
-                finder.save()
+                with finder:
+                    install = finder.get_install_details(exe)
 
         return install
 

--- a/src/ducktools/pythonfinder/venv.py
+++ b/src/ducktools/pythonfinder/venv.py
@@ -36,7 +36,7 @@ from ducktools.lazyimporter import LazyImporter, FromImport, ModuleImport
 
 from .shared import (
     PythonInstall,
-    get_install_details,
+    DetailFinder,
     version_str_to_tuple,
     version_tuple_to_str,
 )
@@ -124,9 +124,15 @@ class PythonVEnv(Prefab):
     def parent_exists(self) -> bool:
         return os.path.exists(self.parent_executable)
 
-    def get_parent_install(self, cache: list[PythonInstall] | None = None) -> PythonInstall | None:
+    def get_parent_install(
+        self,
+        cache: list[PythonInstall] | None = None,
+        finder: DetailFinder | None = None,
+    ) -> PythonInstall | None:
         install = None
         cache = [] if cache is None else cache
+
+        finder = DetailFinder() if finder is None else finder
 
         if self.parent_exists:
             exe = self.parent_executable
@@ -138,7 +144,8 @@ class PythonVEnv(Prefab):
                     break
 
             if install is None:
-                install = get_install_details(exe)
+                install = finder.get_install_details(exe)
+                finder.save()
 
         return install
 

--- a/src/ducktools/pythonfinder/win32/__init__.py
+++ b/src/ducktools/pythonfinder/win32/__init__.py
@@ -25,18 +25,26 @@ from __future__ import annotations
 from _collections_abc import Iterator
 import itertools
 
-from ..shared import PythonInstall, get_uv_pythons
+from ..shared import PythonInstall, get_uv_pythons, DetailFinder
 from .pyenv_search import get_pyenv_pythons
 from .registry_search import get_registered_pythons
 
 
-def get_python_installs(*, query_executables: bool = True) -> Iterator[PythonInstall]:
+def get_python_installs(
+    *,
+    query_executables: bool = True,
+    finder: DetailFinder | None = None
+) -> Iterator[PythonInstall]:
     listed_installs = set()
-    for py in itertools.chain(
-        get_registered_pythons(),
-        get_pyenv_pythons(query_executables=query_executables),
-        get_uv_pythons(query_executables=query_executables),
-    ):
-        if py.executable not in listed_installs:
-            yield py
-            listed_installs.add(py.executable)
+
+    finder = DetailFinder() if finder is None else finder
+
+    with finder:
+        for py in itertools.chain(
+            get_registered_pythons(),
+            get_pyenv_pythons(query_executables=query_executables, finder=finder),
+            get_uv_pythons(query_executables=query_executables, finder=finder),
+        ):
+            if py.executable not in listed_installs:
+                yield py
+                listed_installs.add(py.executable)

--- a/src/ducktools/pythonfinder/win32/pyenv_search.py
+++ b/src/ducktools/pythonfinder/win32/pyenv_search.py
@@ -26,7 +26,7 @@ import os
 import os.path
 from _collections_abc import Iterator
 
-from ..shared import PythonInstall, get_install_details
+from ..shared import PythonInstall, DetailFinder
 
 
 def get_pyenv_root() -> str | None:
@@ -40,6 +40,7 @@ def get_pyenv_pythons(
     versions_folder: str | os.PathLike | None = None,
     *,
     query_executables: bool = True,
+    finder: DetailFinder | None = None,
 ) -> Iterator[PythonInstall]:
 
     if versions_folder is None:
@@ -49,54 +50,57 @@ def get_pyenv_pythons(
     if versions_folder is None or not os.path.exists(versions_folder):
         return
 
-    for p in os.scandir(versions_folder):
-        path_base = os.path.basename(p.path)
+    finder = DetailFinder() if finder is None else finder
 
-        if query_executables:
-            # Check for pypy/graalpy
-            if path_base.startswith("pypy"):
-                executable = os.path.join(p.path, "pypy.exe")
-                if os.path.exists(executable):
-                    yield get_install_details(executable, managed_by="pyenv")
-                    continue
-            elif path_base.startswith("graalpy"):
-                # Graalpy exe in bin subfolder
-                executable = os.path.join(p.path, "bin", "graalpy.exe")
-                if os.path.exists(executable):
-                    yield get_install_details(executable, managed_by="pyenv")
-                    continue
+    with finder:
+        for p in os.scandir(versions_folder):
+            path_base = os.path.basename(p.path)
 
-        # Regular CPython
-        executable = os.path.join(p.path, "python.exe")
+            if query_executables:
+                # Check for pypy/graalpy
+                if path_base.startswith("pypy"):
+                    executable = os.path.join(p.path, "pypy.exe")
+                    if os.path.exists(executable):
+                        yield finder.get_install_details(executable, managed_by="pyenv")
+                        continue
+                elif path_base.startswith("graalpy"):
+                    # Graalpy exe in bin subfolder
+                    executable = os.path.join(p.path, "bin", "graalpy.exe")
+                    if os.path.exists(executable):
+                        yield finder.get_install_details(executable, managed_by="pyenv")
+                        continue
 
-        if os.path.exists(executable):
-            split_version = p.name.split("-")
+            # Regular CPython
+            executable = os.path.join(p.path, "python.exe")
 
-            # If there are 1 or 2 arguments this is a recognised version
-            # Otherwise it is unrecognised
-            if len(split_version) == 2:
-                version, arch = split_version
+            if os.path.exists(executable):
+                split_version = p.name.split("-")
 
-                # win32 in pyenv name means 32 bit python install
-                # 'arm' is the only alternative which will be 64bit
-                arch = "32bit" if arch == "win32" else "64bit"
-                try:
-                    yield PythonInstall.from_str(
-                        version=version,
-                        executable=executable,
-                        architecture=arch,
-                        managed_by="pyenv",
-                    )
-                except ValueError:
-                    pass
-            elif len(split_version) == 1:
-                version = split_version[0]
-                try:
-                    yield PythonInstall.from_str(
-                        version=version,
-                        executable=executable,
-                        architecture="64bit",
-                        managed_by="pyenv",
-                    )
-                except ValueError:
-                    pass
+                # If there are 1 or 2 arguments this is a recognised version
+                # Otherwise it is unrecognised
+                if len(split_version) == 2:
+                    version, arch = split_version
+
+                    # win32 in pyenv name means 32 bit python install
+                    # 'arm' is the only alternative which will be 64bit
+                    arch = "32bit" if arch == "win32" else "64bit"
+                    try:
+                        yield PythonInstall.from_str(
+                            version=version,
+                            executable=executable,
+                            architecture=arch,
+                            managed_by="pyenv",
+                        )
+                    except ValueError:
+                        pass
+                elif len(split_version) == 1:
+                    version = split_version[0]
+                    try:
+                        yield PythonInstall.from_str(
+                            version=version,
+                            executable=executable,
+                            architecture="64bit",
+                            managed_by="pyenv",
+                        )
+                    except ValueError:
+                        pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def uses_details_script(fs):
     fs.add_real_file(details_script.__file__)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def temp_finder():
     with tempfile.TemporaryDirectory() as tmpdir:
         temp_cache_path = os.path.join(tmpdir, "cache.json")
@@ -51,7 +51,7 @@ def temp_finder():
         yield finder
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def this_python(temp_finder):
     config_exe = sysconfig.get_config_var("EXENAME")
 
@@ -70,7 +70,7 @@ def this_python(temp_finder):
     return temp_finder.query_install(str(py_exe))
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def this_venv(temp_finder):
     if sys.platform == "win32":
         exe = sys.executable

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,192 @@
+# ducktools-pythonfinder
+# MIT License
+# 
+# Copyright (c) 2025 David C Ellis
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os.path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ducktools.pythonfinder.shared import DetailFinder, PythonInstall
+
+fake_python_path = "/path/to/python"
+example_json = """
+{
+    "version": [3, 13, 2, "final", 0], 
+    "executable": "/path/to/python", 
+    "architecture": "64bit", 
+    "implementation": "cpython", 
+    "metadata": {"freethreaded": false}
+}
+""".strip()
+
+example_install = PythonInstall(
+    version=(3, 13, 2, "final", 0),
+    executable=fake_python_path,
+    architecture="64bit",
+    implementation="cpython",
+    metadata={"freethreaded": False}
+)
+
+
+@pytest.fixture
+def run_mock():
+    with patch("subprocess.run") as mock:
+        mock.return_value.stdout = example_json
+        yield mock
+
+
+@pytest.fixture
+def stat_mock():
+    result = SimpleNamespace(st_mtime=1739886571)
+    with patch("os.stat") as mock:
+        mock.return_value = result
+        yield
+
+
+def test_run(run_mock, temp_finder):
+    with temp_finder:
+        result = temp_finder.query_install(fake_python_path)
+
+    assert result == example_install
+
+
+def test_save_on_exit(run_mock, stat_mock, temp_finder):
+    with patch.object(DetailFinder, "save") as save_mock:
+        with temp_finder:
+            details = temp_finder.get_install_details(fake_python_path)
+
+        assert details == example_install
+        save_mock.assert_called()
+
+
+def test_save_only_if_changed(run_mock, stat_mock, temp_finder):
+    with patch.object(DetailFinder, "save") as save_mock:
+        with temp_finder:
+            details = temp_finder.get_install_details(fake_python_path)
+
+        assert details == example_install
+        save_mock.assert_called()
+        save_mock.reset_mock()
+        temp_finder._dirty_cache = False  # This would be reset by save
+
+        # Should fetch from cache and not call the save mock again
+        with temp_finder:
+            details = temp_finder.get_install_details(fake_python_path)
+
+        assert details == example_install
+
+        save_mock.assert_not_called()
+
+
+def test_save_only_final_exit(run_mock, stat_mock, temp_finder):
+    with patch.object(DetailFinder, "save") as save_mock:
+        with temp_finder:
+            with temp_finder:
+                details = temp_finder.get_install_details(fake_python_path)
+                assert details == example_install
+            # Exit 1 level, should not call save yet
+            save_mock.assert_not_called()
+        # Full exit, should be called
+        save_mock.assert_called()
+
+def test_clear_cache(run_mock, stat_mock, temp_finder):
+    with patch.object(DetailFinder, "save") as save_mock:
+        with temp_finder:
+            details = temp_finder.get_install_details(fake_python_path)
+
+        assert details == example_install
+        save_mock.assert_called()
+        save_mock.reset_mock()
+        temp_finder._dirty_cache = False  # This would be reset by save
+
+        # Clear the cache
+        with temp_finder:
+            temp_finder.clear_cache()
+
+        save_mock.assert_called()
+        save_mock.reset_mock()
+        temp_finder._dirty_cache = False  # This would be reset by save
+
+        # Cache cleared, should get the details again and save
+        with temp_finder:
+            details = temp_finder.get_install_details(fake_python_path)
+
+        assert details == example_install
+
+        save_mock.assert_called()
+
+def test_clear_invalid_runtimes(run_mock, stat_mock, temp_finder):
+    with patch.object(DetailFinder, "save") as save_mock:
+        # First fill cache
+        with temp_finder:
+            temp_finder.get_install_details(fake_python_path)
+
+        save_mock.assert_called()
+        save_mock.reset_mock()
+        temp_finder._dirty_cache = False  # This would be reset by save
+
+        with temp_finder, patch("os.path.exists") as exists_patch:
+            exists_patch.return_value = True
+            temp_finder.clear_invalid_runtimes()
+        
+        save_mock.assert_not_called()
+        assert os.path.abspath(fake_python_path) in temp_finder.raw_cache
+
+        with temp_finder, patch("os.path.exists") as exists_patch:
+            exists_patch.return_value = False
+            temp_finder.clear_invalid_runtimes()
+
+        save_mock.assert_called()
+        assert os.path.abspath(fake_python_path) not in temp_finder.raw_cache
+
+
+def test_changed_stat_invalidates(run_mock, temp_finder):
+    fake_abspath = os.path.abspath(fake_python_path)
+
+    result = SimpleNamespace(st_mtime=1739886571)
+    changed_result = SimpleNamespace(st_mtime=1739886572)
+
+    with patch("os.stat") as statmock, patch.object(DetailFinder, "query_install") as querymock:
+        statmock.return_value = result
+        querymock.return_value = example_install
+
+        with temp_finder:
+            details = temp_finder.get_install_details(fake_python_path)
+        
+        assert temp_finder.raw_cache[fake_abspath]["mtime"] == 1739886571
+
+        querymock.assert_called_with(fake_abspath, None)
+        querymock.reset_mock()
+        
+        with temp_finder:
+            details = temp_finder.get_install_details(fake_python_path)
+        
+        assert temp_finder.raw_cache[fake_abspath]["mtime"] == 1739886571
+        querymock.assert_not_called()
+
+        statmock.return_value = changed_result
+        with temp_finder:
+            details = temp_finder.get_install_details(fake_python_path)
+
+        assert temp_finder.raw_cache[fake_abspath]["mtime"] == 1739886572
+        querymock.assert_called()

--- a/tests/test_pyenv.py
+++ b/tests/test_pyenv.py
@@ -224,7 +224,7 @@ def test_pypy_version(fs, temp_finder):
     # Test pypy version retrieval
 
     ver_folder = "pypy3.10-7.3.15"
-    tmpdir = "~/.pyenv/versions"
+    tmpdir = os.path.expanduser("~/.pyenv/versions")
 
     mock_output = textwrap.dedent(
         """
@@ -239,6 +239,7 @@ def test_pypy_version(fs, temp_finder):
     py_folder = os.path.join(tmpdir, ver_folder)
     py_exe = os.path.join(py_folder, "bin/python")
 
+    fs.add_real_file(details_script.__file__)
     fs.create_dir(py_folder)
     fs.create_dir(os.path.join(py_folder, "bin"))
     fs.create_file(py_exe)
@@ -248,7 +249,7 @@ def test_pypy_version(fs, temp_finder):
         versions = list(get_pyenv_pythons(tmpdir, finder=temp_finder))
 
         run_cmd.assert_called_once_with(
-            [py_exe, "-"],
+            [os.path.abspath(py_exe), "-"],
             input=details_text,
             capture_output=True,
             text=True,

--- a/tests/test_pyenv.py
+++ b/tests/test_pyenv.py
@@ -70,13 +70,13 @@ def test_get_pyenv_root_backup():
     assert pyenv_root == "path/to/pyenv"
 
 
-def test_no_versions_folder():
+def test_no_versions_folder(temp_finder):
     with patch("os.path.exists") as exists_mock:
         exists_mock.return_value = False
-        assert list(get_pyenv_pythons()) == []
+        assert list(get_pyenv_pythons(finder=temp_finder)) == []
 
 
-def test_mock_versions_folder():
+def test_mock_versions_folder(temp_finder):
     mock_dir_entry = Mock(os.DirEntry)
 
     out_ver = "3.12.1"
@@ -94,13 +94,13 @@ def test_mock_versions_folder():
         exists_mock.return_value = True
         scandir_mock.return_value = iter([mock_dir_entry])
 
-        python_versions = list(get_pyenv_pythons(versions_folder="~/fake/versions"))
+        python_versions = list(get_pyenv_pythons(versions_folder="~/fake/versions", finder=temp_finder))
 
     assert python_versions == [PythonInstall.from_str(version=out_ver, executable=out_executable, managed_by="pyenv")]
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Test for Windows only")
-def test_fs_versions_win(fs):
+def test_fs_versions_win(fs, temp_finder):
     # Test with folders in fake file system
 
     tmpdir = "c:\\fake_folder"
@@ -111,13 +111,13 @@ def test_fs_versions_win(fs):
     fs.create_dir(py_folder)
     fs.create_file(py_exe)
 
-    versions = list(get_pyenv_pythons(tmpdir))
+    versions = list(get_pyenv_pythons(tmpdir, finder=temp_finder))
 
     assert versions == [PythonInstall.from_str(version="3.12.1", executable=py_exe, managed_by="pyenv")]
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Test for Windows only")
-def test_32bit_version(fs):
+def test_32bit_version(fs, temp_finder):
     # Test with folders in fake file system
 
     tmpdir = "c:\\fake_folder"
@@ -128,7 +128,7 @@ def test_32bit_version(fs):
     fs.create_dir(py_folder)
     fs.create_file(py_exe)
 
-    versions = list(get_pyenv_pythons(tmpdir))
+    versions = list(get_pyenv_pythons(tmpdir, finder=temp_finder))
 
     assert versions == [
         PythonInstall.from_str(version="3.12.1", executable=py_exe, architecture="32bit", managed_by="pyenv")
@@ -136,7 +136,7 @@ def test_32bit_version(fs):
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Test for Windows only")
-def test_invalid_ver_win(fs, uses_details_script):
+def test_invalid_ver_win(fs, uses_details_script, temp_finder):
     # Ignore non-standard versions
 
     pyenv_fld = "C:\\Fake_Folder"
@@ -160,14 +160,14 @@ def test_invalid_ver_win(fs, uses_details_script):
     fs.create_file(py3_exe)
 
     with patch("subprocess.run") as run_mock:
-        versions = list(get_pyenv_pythons(pyenv_fld))
+        versions = list(get_pyenv_pythons(pyenv_fld, finder=temp_finder))
         run_mock.assert_not_called()
 
     assert versions == []
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Test for non-Windows only")
-def test_fs_versions_nix(fs):
+def test_fs_versions_nix(fs, temp_finder):
     # Test folders in fake file system
 
     tmpdir = "~/.pyenv/versions"
@@ -179,13 +179,13 @@ def test_fs_versions_nix(fs):
     fs.create_dir(os.path.join(py_folder, "bin"))
     fs.create_file(py_exe)
 
-    versions = list(get_pyenv_pythons(tmpdir))
+    versions = list(get_pyenv_pythons(tmpdir, finder=temp_finder))
 
     assert versions == [PythonInstall.from_str(version="3.12.1", executable=py_exe, managed_by="pyenv")]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Test for non-Windows only")
-def test_invalid_ver_nix(fs, uses_details_script):
+def test_invalid_ver_nix(fs, uses_details_script, temp_finder):
     # Test folders in fake file system
 
     tmpdir = "~/.pyenv/versions"
@@ -213,14 +213,14 @@ def test_invalid_ver_nix(fs, uses_details_script):
 
     with patch("subprocess.run") as run_mock:
         run_mock.side_effect = OSError("Failure")
-        versions = list(get_pyenv_pythons(tmpdir))
+        versions = list(get_pyenv_pythons(tmpdir, finder=temp_finder))
         assert run_mock.call_count == 3
 
     assert versions == []
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Test for non-Windows only")
-def test_pypy_version(fs):
+def test_pypy_version(fs, temp_finder):
     # Test pypy version retrieval
 
     ver_folder = "pypy3.10-7.3.15"
@@ -245,7 +245,7 @@ def test_pypy_version(fs):
 
     with patch("subprocess.run") as run_cmd:
         run_cmd.return_value.stdout = mock_output
-        versions = list(get_pyenv_pythons(tmpdir))
+        versions = list(get_pyenv_pythons(tmpdir, finder=temp_finder))
 
         run_cmd.assert_called_once_with(
             [py_exe, "-"],

--- a/tests/test_uv_finder.py
+++ b/tests/test_uv_finder.py
@@ -121,27 +121,27 @@ class TestUVReal:
         assert pythons == []
 
     @pytest.mark.uv_python
-    def test_finds_installed_python(self, uv_pythondir):
+    def test_finds_installed_python(self, uv_pythondir, temp_finder):
         # Install python 3.12.6 in the tempdir
         subprocess.run(
             ["uv", "python", "install", "3.12.6"],
             check=True,
         )
 
-        pythons = list(get_uv_pythons())
+        pythons = list(get_uv_pythons(finder=temp_finder))
         assert len(pythons) == 1
         assert pythons[0].version_str == "3.12.6"
         assert pythons[0].implementation == "cpython"
         assert pythons[0].managed_by == "Astral UV"
 
     @pytest.mark.uv_python
-    def test_finds_installed_pypy(self, uv_pythondir):
+    def test_finds_installed_pypy(self, uv_pythondir, temp_finder):
         subprocess.run(
             ["uv", "python", "install", "pypy3.10"],
             check=True,
         )
 
-        pythons = list(get_uv_pythons())
+        pythons = list(get_uv_pythons(finder=temp_finder))
         assert len(pythons) == 1
         assert pythons[0].version >= (3, 10, 14)
         assert pythons[0].implementation == "pypy"

--- a/tests/test_uv_finder.py
+++ b/tests/test_uv_finder.py
@@ -20,7 +20,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+import json
 import os
 import re
 import subprocess
@@ -42,7 +42,13 @@ UV_REASON = "UV is not installed - skipping tests that run UV"
 
 
 @pytest.fixture
-def uv_pythondir():
+def prevent_cache():
+    with mock.patch("json.load", side_effect=json.JSONDecodeError('', '', 0)) as break_json:
+        yield
+
+
+@pytest.fixture
+def uv_pythondir(prevent_cache):
     # Set the UV python folder to a temporary folder and
     # yield the temporary folder value
     uv_python_envkey = "UV_PYTHON_INSTALL_DIR"

--- a/tests/test_venv_finder.py
+++ b/tests/test_venv_finder.py
@@ -132,10 +132,10 @@ def test_found_parent(with_venvs, this_python, this_venv):
     assert venv_ex.version[:3] == parent.version[:3]
 
 
-def test_found_parent_cache(with_venvs, this_python):
+def test_found_parent_cache(with_venvs, this_python, temp_finder):
     venv_ex = list_python_venvs(base_dir=with_venvs, recursive=False)[0]
 
-    parent = venv_ex.get_parent_install(cache=[this_python])
+    parent = venv_ex.get_parent_install(cache=[this_python], finder=temp_finder)
     assert parent == this_python
 
 


### PR DESCRIPTION
Invalidates if `mtime` changes or manually.

Currently this only operates on Python installs that required querying as there was no static info available. 

However this may eventually move to querying *all* python installs on the basis that the static data may be inaccurate and also to remove code for extracting details specific to different tools.