### PR TITLE
Don't rely on uv/pyenv/windows registry for runtime details - use the script and cache.

### DIFF
--- a/src/ducktools/pythonfinder/__init__.py
+++ b/src/ducktools/pythonfinder/__init__.py
@@ -20,7 +20,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+from __future__ import annotations
 # Find platform python versions
 
 __all__ = [
@@ -43,10 +43,10 @@ else:
     from .linux import get_python_installs
 
 
-def list_python_installs(*, query_executables: bool = True, finder: "DetailFinder | None" = None):
+def list_python_installs(*, finder: DetailFinder | None = None):
     finder = DetailFinder() if finder is None else finder
     return sorted(
-        get_python_installs(query_executables=query_executables, finder=finder),
+        get_python_installs(finder=finder),
         reverse=True,
         key=lambda x: (x.version[3], *x.version[:3], x.version[4])
     )

--- a/src/ducktools/pythonfinder/__main__.py
+++ b/src/ducktools/pythonfinder/__main__.py
@@ -115,11 +115,6 @@ def get_parser():
         description="Discover base Python installs",
     )
     parser.add_argument("-V", "--version", action="version", version=__version__)
-    parser.add_argument(
-        "--fast",
-        action="store_true",
-        help="Skip Python installs that need to be launched to obtain metadata"
-    )
 
     subparsers = parser.add_subparsers(dest="command", required=False)
 
@@ -169,7 +164,6 @@ def display_local_installs(
     min_ver=None,
     max_ver=None,
     compatible=None,
-    query_executables=True,
 ):
     if min_ver:
         min_ver = tuple(int(i) for i in min_ver.split("."))
@@ -178,7 +172,7 @@ def display_local_installs(
     if compatible:
         compatible = tuple(int(i) for i in compatible.split("."))
 
-    installs = list_python_installs(query_executables=query_executables)
+    installs = list_python_installs()
 
     headings = ["Version", "Executable Location"]
 
@@ -333,7 +327,6 @@ def main():
                 min_ver=vals.min,
                 max_ver=vals.max,
                 compatible=vals.compatible,
-                query_executables=not vals.fast,
             )
     else:
         # No arguments to parse

--- a/src/ducktools/pythonfinder/details_script.py
+++ b/src/ducktools/pythonfinder/details_script.py
@@ -90,7 +90,6 @@ def get_details():
                 freethreaded = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
                 metadata["freethreaded"] = freethreaded
 
-
     install = dict(
         version=list(sys.version_info),
         executable=sys.executable,

--- a/src/ducktools/pythonfinder/linux/__init__.py
+++ b/src/ducktools/pythonfinder/linux/__init__.py
@@ -73,7 +73,6 @@ def get_path_pythons(*, finder: DetailFinder | None = None) -> Iterator[PythonIn
 
 def get_python_installs(
     *,
-    query_executables: bool = True,
     finder: DetailFinder | None = None,
 ) -> Iterator[PythonInstall]:
     listed_pythons = set()
@@ -81,12 +80,10 @@ def get_python_installs(
     finder = DetailFinder() if finder is None else finder
 
     chain_commands = [
-        get_pyenv_pythons(query_executables=query_executables, finder=finder),
-        get_uv_pythons(query_executables=query_executables, finder=finder),
+        get_pyenv_pythons(finder=finder),
+        get_uv_pythons(finder=finder),
+        get_path_pythons(finder=finder),
     ]
-    if query_executables:
-        chain_commands.append(get_path_pythons(finder=finder))
-
     with finder:
         for py in itertools.chain.from_iterable(chain_commands):
             if py.executable not in listed_pythons:

--- a/src/ducktools/pythonfinder/win32/__init__.py
+++ b/src/ducktools/pythonfinder/win32/__init__.py
@@ -32,7 +32,6 @@ from .registry_search import get_registered_pythons
 
 def get_python_installs(
     *,
-    query_executables: bool = True,
     finder: DetailFinder | None = None
 ) -> Iterator[PythonInstall]:
     listed_installs = set()
@@ -42,8 +41,8 @@ def get_python_installs(
     with finder:
         for py in itertools.chain(
             get_registered_pythons(),
-            get_pyenv_pythons(query_executables=query_executables, finder=finder),
-            get_uv_pythons(query_executables=query_executables, finder=finder),
+            get_pyenv_pythons(finder=finder),
+            get_uv_pythons(finder=finder),
         ):
             if py.executable not in listed_installs:
                 yield py

--- a/src/ducktools/pythonfinder/win32/registry_search.py
+++ b/src/ducktools/pythonfinder/win32/registry_search.py
@@ -28,10 +28,11 @@ Search the Windows registry to find python installs
 Based on PEP 514 registry entries.
 """
 
+import os.path
 import winreg  # noqa  # pycharm seems to think winreg doesn't exist in python3.12
 from _collections_abc import Iterator
 
-from ..shared import PythonInstall, version_str_to_tuple
+from ..shared import DetailFinder, PythonInstall, version_str_to_tuple
 
 exclude_companies = {
     "PyLauncher",  # pylauncher is special cased to be ignored
@@ -59,78 +60,65 @@ def enum_values(key):
         yield winreg.EnumValue(key, i)
 
 
-def get_registered_pythons() -> Iterator[PythonInstall]:
-    for base, py_folder, flags in check_pairs:
-        base_key = None
-        try:
-            base_key = winreg.OpenKeyEx(base, py_folder, access=winreg.KEY_READ | flags)
-        except FileNotFoundError:
-            continue
-        else:
-            # Query the base folder eg: HKEY_LOCAL_MACHINE\SOFTWARE\Python
-            # The values here should be "companies" as defined in the PEP
-            for company in enum_keys(base_key):
-                if company in exclude_companies:
-                    continue
+def get_registered_pythons(finder: DetailFinder | None = None) -> Iterator[PythonInstall]:
+    finder = DetailFinder() if finder is None else finder
 
-                with winreg.OpenKey(base_key, company) as company_key:
-                    comp_metadata = {
-                        "Company": company
-                    }
+    with finder:
+        for base, py_folder, flags in check_pairs:
+            base_key = None
+            try:
+                base_key = winreg.OpenKeyEx(base, py_folder, access=winreg.KEY_READ | flags)
+            except FileNotFoundError:
+                continue
+            else:
+                # Query the base folder eg: HKEY_LOCAL_MACHINE\SOFTWARE\Python
+                # The values here should be "companies" as defined in the PEP
+                for company in enum_keys(base_key):
+                    if company in exclude_companies:
+                        continue
 
-                    for name, data, _ in enum_values(company_key):
-                        comp_metadata[f"Company{name}"] = data
-
-                    for py_keyname in enum_keys(company_key):
-                        metadata = {
-                            **comp_metadata,
-                            "Tag": py_keyname,
+                    with winreg.OpenKey(base_key, company) as company_key:
+                        comp_metadata = {
+                            "Company": company
                         }
 
-                        with winreg.OpenKey(company_key, py_keyname) as py_key:
-                            for name, data, _ in enum_values(py_key):
-                                metadata[name] = data
+                        for name, data, _ in enum_values(company_key):
+                            comp_metadata[f"Company{name}"] = data
 
-                            install_key = None
-                            try:
-                                install_key = winreg.OpenKey(py_key, "InstallPath")
-                                python_path, _ = winreg.QueryValueEx(
-                                    install_key,
-                                    "ExecutablePath",
-                                )
-                            except FileNotFoundError:
-                                python_path = None
-                            finally:
-                                if install_key:
-                                    winreg.CloseKey(install_key)
+                        for py_keyname in enum_keys(company_key):
+                            metadata = {
+                                **comp_metadata,
+                                "Tag": py_keyname,
+                            }
 
-                            python_version: str | None = metadata.get("Version")
+                            with winreg.OpenKey(company_key, py_keyname) as py_key:
+                                for name, data, _ in enum_values(py_key):
+                                    metadata[name] = data
 
-                            architecture = metadata.get("SysArchitecture")
+                                install_key = None
+                                try:
+                                    install_key = winreg.OpenKey(py_key, "InstallPath")
+                                    python_path, _ = winreg.QueryValueEx(
+                                        install_key,
+                                        "ExecutablePath",
+                                    )
+                                except FileNotFoundError:
+                                    python_path = None
+                                finally:
+                                    if install_key:
+                                        winreg.CloseKey(install_key)
 
-                            metadata["InWindowsRegistry"] = True
+                                metadata["InWindowsRegistry"] = True
 
-                        if python_path and python_version:
-                            # Pyenv puts architecture information in the Version value for some reason
-                            python_version = python_version.split("-")[0]
-                            version_tuple = version_str_to_tuple(python_version)
+                            if python_path:
+                                # Pyenv puts architecture information in the Version value for some reason
+                                if os.path.isfile(python_path):
+                                    yield finder.get_install_details(
+                                        python_path,
+                                        managed_by=metadata["Company"],
+                                        metadata=metadata,
+                                    )
 
-                            if (
-                                version_tuple >= (3, 13)
-                                and "freethreaded" in metadata.get("DisplayName", "")
-                            ):
-                                metadata["freethreaded"] = True
-                            try:
-                                yield PythonInstall(
-                                    version=version_tuple,
-                                    executable=python_path,
-                                    architecture=architecture,
-                                    metadata=metadata,
-                                    managed_by=metadata["Company"],
-                                )
-                            except ValueError:
-                                pass
-
-        finally:
-            if base_key:
-                winreg.CloseKey(base_key)
+            finally:
+                if base_key:
+                    winreg.CloseKey(base_key)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -210,7 +210,7 @@ def test_changed_stat_invalidates(run_mock, temp_finder):
 
             assert temp_finder.raw_cache[fake_abspath]["mtime"] == 1739886571
 
-            querymock.assert_called_with(fake_abspath, None)
+            querymock.assert_called_with(fake_abspath, None, None)
             querymock.reset_mock()
 
             with temp_finder:

--- a/tests/test_foldersearch.py
+++ b/tests/test_foldersearch.py
@@ -119,7 +119,7 @@ def test_get_folder_pythons(fs, temp_finder):
     fs.create_file(pypy_exe)
     fs.create_file(non_python_file)
 
-    def mock_func(pth):
+    def mock_func(pth, managed_by=None, metadata=None):
         return pth
 
     with patch.object(
@@ -130,8 +130,8 @@ def test_get_folder_pythons(fs, temp_finder):
 
         get_dets.assert_has_calls(
             [
-                call(python_exe),
-                call(pypy_exe),
+                call(python_exe, managed_by=None),
+                call(pypy_exe, managed_by=None),
             ],
             any_order=True,
         )

--- a/tests/test_pyenv.py
+++ b/tests/test_pyenv.py
@@ -90,11 +90,10 @@ def test_mock_versions_folder(temp_finder):
     mock_dir_entry.name = out_ver
     mock_dir_entry.path = os.path.join(versions_folder, out_ver)
 
-    with (
-        patch("os.path.exists") as exists_mock,
-        patch("os.scandir") as scandir_mock,
-        patch.object(DetailFinder, "get_install_details") as details_mock,
-    ):
+    with patch("os.path.exists") as exists_mock, \
+            patch("os.scandir") as scandir_mock, \
+            patch.object(DetailFinder, "get_install_details") as details_mock:
+
         return_val = PythonInstall.from_str(version=out_ver, executable=out_executable, managed_by="pyenv")
         details_mock.return_value = return_val
         exists_mock.return_value = True

--- a/tests/test_pyenv.py
+++ b/tests/test_pyenv.py
@@ -31,7 +31,7 @@ from pathlib import Path
 import pytest
 from unittest.mock import patch, Mock
 
-from ducktools.pythonfinder.shared import PythonInstall
+from ducktools.pythonfinder.shared import PythonInstall, DetailFinder
 from ducktools.pythonfinder import details_script
 
 if sys.platform == "win32":
@@ -90,13 +90,21 @@ def test_mock_versions_folder(temp_finder):
     mock_dir_entry.name = out_ver
     mock_dir_entry.path = os.path.join(versions_folder, out_ver)
 
-    with patch("os.path.exists") as exists_mock, patch("os.scandir") as scandir_mock:
+    with (
+        patch("os.path.exists") as exists_mock,
+        patch("os.scandir") as scandir_mock,
+        patch.object(DetailFinder, "get_install_details") as details_mock,
+    ):
+        return_val = PythonInstall.from_str(version=out_ver, executable=out_executable, managed_by="pyenv")
+        details_mock.return_value = return_val
         exists_mock.return_value = True
         scandir_mock.return_value = iter([mock_dir_entry])
 
-        python_versions = list(get_pyenv_pythons(versions_folder="~/fake/versions", finder=temp_finder))
+        python_versions = list(get_pyenv_pythons(versions_folder=versions_folder, finder=temp_finder))
 
-    assert python_versions == [PythonInstall.from_str(version=out_ver, executable=out_executable, managed_by="pyenv")]
+        details_mock.assert_called_once_with(out_executable, managed_by="pyenv")
+
+    assert python_versions == [return_val]
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Test for Windows only")
@@ -111,59 +119,14 @@ def test_fs_versions_win(fs, temp_finder):
     fs.create_dir(py_folder)
     fs.create_file(py_exe)
 
-    versions = list(get_pyenv_pythons(tmpdir, finder=temp_finder))
+    with patch.object(DetailFinder, "get_install_details") as details_mock:
+        return_val = PythonInstall.from_str(version="3.12.1", executable=py_exe, managed_by="pyenv")
+        details_mock.return_value = return_val
+        versions = list(get_pyenv_pythons(tmpdir, finder=temp_finder))
+
+        details_mock.assert_called_once_with(py_exe, managed_by="pyenv")
 
     assert versions == [PythonInstall.from_str(version="3.12.1", executable=py_exe, managed_by="pyenv")]
-
-
-@pytest.mark.skipif(sys.platform != "win32", reason="Test for Windows only")
-def test_32bit_version(fs, temp_finder):
-    # Test with folders in fake file system
-
-    tmpdir = "c:\\fake_folder"
-
-    py_folder = os.path.join(tmpdir, "3.12.1-win32")
-    py_exe = os.path.join(py_folder, "python.exe")
-
-    fs.create_dir(py_folder)
-    fs.create_file(py_exe)
-
-    versions = list(get_pyenv_pythons(tmpdir, finder=temp_finder))
-
-    assert versions == [
-        PythonInstall.from_str(version="3.12.1", executable=py_exe, architecture="32bit", managed_by="pyenv")
-    ]
-
-
-@pytest.mark.skipif(sys.platform != "win32", reason="Test for Windows only")
-def test_invalid_ver_win(fs, uses_details_script, temp_finder):
-    # Ignore non-standard versions
-
-    pyenv_fld = "C:\\Fake_Folder"
-
-    py_folder = os.path.join(pyenv_fld, "external-python3.12.1")
-    py_exe = os.path.join(py_folder, "python.exe")
-
-    fs.create_dir(py_folder)
-    fs.create_file(py_exe)
-
-    py2_folder = os.path.join(pyenv_fld, "ext3.13.0")
-    py2_exe = os.path.join(py2_folder, "python.exe")
-
-    fs.create_dir(py2_folder)
-    fs.create_file(py2_exe)
-
-    py3_folder = os.path.join(pyenv_fld, "invalid-version-3.12.1")
-    py3_exe = os.path.join(py3_folder, "python.exe")
-
-    fs.create_dir(py3_folder)
-    fs.create_file(py3_exe)
-
-    with patch("subprocess.run") as run_mock:
-        versions = list(get_pyenv_pythons(pyenv_fld, finder=temp_finder))
-        run_mock.assert_not_called()
-
-    assert versions == []
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Test for non-Windows only")

--- a/tests/test_pyenv.py
+++ b/tests/test_pyenv.py
@@ -142,7 +142,12 @@ def test_fs_versions_nix(fs, temp_finder):
     fs.create_dir(os.path.join(py_folder, "bin"))
     fs.create_file(py_exe)
 
-    versions = list(get_pyenv_pythons(tmpdir, finder=temp_finder))
+    with patch.object(DetailFinder, "get_install_details") as details_mock:
+        return_val = PythonInstall.from_str(version="3.12.1", executable=py_exe, managed_by="pyenv")
+        details_mock.return_value = return_val
+
+        versions = list(get_pyenv_pythons(tmpdir, finder=temp_finder))
+        details_mock.assert_called_once_with(py_exe, managed_by="pyenv")
 
     assert versions == [PythonInstall.from_str(version="3.12.1", executable=py_exe, managed_by="pyenv")]
 


### PR DESCRIPTION
Previously `ducktools-pythonfinder` would rely on some of the details from uv and pyenv paths and registry entries for its information on runtimes. This has generally proven to be incorrect or inconsistent and subject to unexpected data or other changes.

This PR switches all of the searches to using the details script and querying the runtime directory. Manager specific behaviour is mostly done to discover the runtime paths. This *would* be painfully slow on older versions but with the new caching behaviour this is just as fast as before after the cache has been built.