### PR TITLE
Check if install_details returned a value before yielding

### DIFF
--- a/src/ducktools/pythonfinder/win32/pyenv_search.py
+++ b/src/ducktools/pythonfinder/win32/pyenv_search.py
@@ -72,4 +72,6 @@ def get_pyenv_pythons(
                 executable = os.path.join(p.path, "python.exe")
 
             if os.path.exists(executable):
-                yield finder.get_install_details(executable, managed_by="pyenv")
+                install = finder.get_install_details(executable, managed_by="pyenv")
+                if install:
+                    yield install

--- a/src/ducktools/pythonfinder/win32/registry_search.py
+++ b/src/ducktools/pythonfinder/win32/registry_search.py
@@ -113,11 +113,13 @@ def get_registered_pythons(finder: DetailFinder | None = None) -> Iterator[Pytho
                             if python_path:
                                 # Pyenv puts architecture information in the Version value for some reason
                                 if os.path.isfile(python_path):
-                                    yield finder.get_install_details(
+                                    details = finder.get_install_details(
                                         python_path,
                                         managed_by=metadata["Company"],
                                         metadata=metadata,
                                     )
+                                    if details:
+                                        yield details
 
             finally:
                 if base_key:


### PR DESCRIPTION
This fixes a bug where python.exe exists, but the script fails (for example trying to run an ARM exe on x86_64) and so the return is nothing and then `list_python_installs` fails.