### PR TITLE
Switch the "managed_by" field for UV installs to be "Astral uv"

### DIFF
--- a/src/ducktools/pythonfinder/shared.py
+++ b/src/ducktools/pythonfinder/shared.py
@@ -531,7 +531,7 @@ def _implementation_from_uv_dir(
 
     for pth in python_paths:
         if os.path.exists(pth):
-            install = finder.get_install_details(pth, managed_by="Astral UV")
+            install = finder.get_install_details(pth, managed_by="Astral uv")
             break
 
     return install

--- a/src/ducktools/pythonfinder/shared.py
+++ b/src/ducktools/pythonfinder/shared.py
@@ -531,7 +531,7 @@ def _implementation_from_uv_dir(
 
     for pth in python_paths:
         if os.path.exists(pth):
-            install = finder.get_install_details(pth, managed_by="Astral")
+            install = finder.get_install_details(pth, managed_by="Astral UV")
             break
 
     return install

--- a/tests/test_uv_finder.py
+++ b/tests/test_uv_finder.py
@@ -138,7 +138,7 @@ class TestUVReal:
         assert len(pythons) == 1
         assert pythons[0].version_str == "3.12.6"
         assert pythons[0].implementation == "cpython"
-        assert pythons[0].managed_by == "Astral UV"
+        assert pythons[0].managed_by == "Astral uv"
 
     @pytest.mark.uv_python
     def test_finds_installed_pypy(self, uv_pythondir, temp_finder):
@@ -152,7 +152,7 @@ class TestUVReal:
         assert pythons[0].version >= (3, 10, 14)
         assert pythons[0].implementation == "pypy"
         assert pythons[0].implementation_version >= (7, 3, 17)
-        assert pythons[0].managed_by == "Astral UV"
+        assert pythons[0].managed_by == "Astral uv"
 
 
 def test_regex_matches():


### PR DESCRIPTION
Just in case anyone wasn't sure what 'Astral' was.