### PR TITLE
Add MacOS managed by folders

### DIFF
--- a/src/ducktools/pythonfinder/__main__.py
+++ b/src/ducktools/pythonfinder/__main__.py
@@ -22,7 +22,6 @@
 # SOFTWARE.
 from __future__ import annotations
 
-
 import sys
 import os
 

--- a/src/ducktools/pythonfinder/darwin/__init__.py
+++ b/src/ducktools/pythonfinder/darwin/__init__.py
@@ -35,8 +35,10 @@ from ..shared import get_uv_pythons, DetailFinder,PythonInstall
 # This is the difference from the linux methods
 KNOWN_MANAGED_PATHS = {
     **linux.KNOWN_MANAGED_PATHS,
-    "/opt/homebrew": "Homebrew",
+    "/opt/homebrew": "Homebrew",  # ARM Apple
+    "/usr/local/opt": "Homebrew",  # x86_64 Apple
     "/Applications/Xcode.app": "Xcode",
+    "/Library/Developer/CommandLineTools": "Xcode",  # Xcode commandline tools
     "/Library/Frameworks/Python.framework": "python.org",
 }
 

--- a/src/ducktools/pythonfinder/darwin/__init__.py
+++ b/src/ducktools/pythonfinder/darwin/__init__.py
@@ -20,7 +20,53 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
 
-"""Currently just copied from linux"""
+import itertools
+try:
+    from _collections_abc import Iterator
+except ImportError:
+    from collections.abc import Iterator
 
-from ..linux import get_python_installs, get_path_pythons, get_pyenv_pythons
+from .. import linux
+from ..shared import get_uv_pythons, DetailFinder,PythonInstall
+
+
+# This is the difference from the linux methods
+KNOWN_MANAGED_PATHS = {
+    **linux.KNOWN_MANAGED_PATHS,
+    "/opt/homebrew": "Homebrew",
+    "/Applications/Xcode.app": "Xcode",
+    "/Library/Frameworks/Python.framework": "python.org",
+}
+
+
+def get_path_pythons(
+    *,
+    finder: DetailFinder | None = None,
+    known_paths: dict[str, str] | None = None,
+) -> Iterator[PythonInstall]:
+    
+    known_paths = KNOWN_MANAGED_PATHS if known_paths is None else known_paths
+
+    return linux.get_path_pythons(finder=finder, known_paths=known_paths)
+
+
+def get_python_installs(
+    *,
+    finder: DetailFinder | None = None,
+) -> Iterator[PythonInstall]:
+    listed_pythons = set()
+
+    finder = DetailFinder() if finder is None else finder
+
+    chain_commands = [
+        linux.get_pyenv_pythons(finder=finder),
+        get_uv_pythons(finder=finder),
+        get_path_pythons(finder=finder),
+    ]
+    with finder:
+        for py in itertools.chain.from_iterable(chain_commands):
+            if py.executable not in listed_pythons:
+                yield py
+                listed_pythons.add(py.executable)

--- a/src/ducktools/pythonfinder/linux/__init__.py
+++ b/src/ducktools/pythonfinder/linux/__init__.py
@@ -25,7 +25,11 @@ from __future__ import annotations
 import os
 import os.path
 import itertools
-from _collections_abc import Iterator
+
+try:
+    from _collections_abc import Iterator
+except ImportError:
+    from collections.abc import Iterator
 
 from ..shared import (
     DetailFinder,
@@ -45,7 +49,12 @@ KNOWN_MANAGED_PATHS = {
 }
 
 
-def get_path_pythons(*, finder: DetailFinder | None = None) -> Iterator[PythonInstall]:
+def get_path_pythons(
+    *,
+    finder: DetailFinder | None = None,
+    known_paths: dict[str, str] | None = None,
+) -> Iterator[PythonInstall]:
+
     exe_names = set()
 
     path_folders = os.environ.get("PATH", "").split(":")
@@ -55,6 +64,7 @@ def get_path_pythons(*, finder: DetailFinder | None = None) -> Iterator[PythonIn
     excluded_folders = [pyenv_root, uv_root]
 
     finder = DetailFinder() if finder is None else finder
+    known_paths = KNOWN_MANAGED_PATHS if known_paths is None else known_paths
 
     for fld in path_folders:
         # Don't retrieve pyenv installs
@@ -71,7 +81,7 @@ def get_path_pythons(*, finder: DetailFinder | None = None) -> Iterator[PythonIn
             continue
 
         for install in get_folder_pythons(fld, finder=finder):
-            if manager := KNOWN_MANAGED_PATHS.get(os.path.dirname(install.executable)):
+            if manager := known_paths.get(os.path.dirname(install.executable)):
                 install.managed_by = manager
 
             name = os.path.basename(install.executable)

--- a/src/ducktools/pythonfinder/linux/__init__.py
+++ b/src/ducktools/pythonfinder/linux/__init__.py
@@ -81,8 +81,10 @@ def get_path_pythons(
             continue
 
         for install in get_folder_pythons(fld, finder=finder):
-            if manager := known_paths.get(os.path.dirname(install.executable)):
-                install.managed_by = manager
+            for path, manager in known_paths.items():
+                if os.path.commonpath((path, install.executable)) == path:
+                    install.managed_by = manager
+                    break
 
             name = os.path.basename(install.executable)
             if name in exe_names:

--- a/src/ducktools/pythonfinder/linux/pyenv_search.py
+++ b/src/ducktools/pythonfinder/linux/pyenv_search.py
@@ -20,15 +20,19 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import annotations
-
 """
 Discover python installs that have been created with pyenv
 """
 
+from __future__ import annotations
+
 import os
 import os.path
-from _collections_abc import Iterator
+
+try:
+    from _collections_abc import Iterator
+except ImportError:
+    from collections.abc import Iterator
 
 from ducktools.lazyimporter import LazyImporter, FromImport, ModuleImport
 

--- a/src/ducktools/pythonfinder/shared.py
+++ b/src/ducktools/pythonfinder/shared.py
@@ -26,7 +26,10 @@ import sys
 import os
 import os.path
 
-from _collections_abc import Iterator
+try:
+    from _collections_abc import Iterator
+except ImportError:
+    from collections.abc import Iterator
 
 from ducktools.classbuilder.prefab import Prefab, attribute, as_dict
 from ducktools.lazyimporter import LazyImporter, ModuleImport, FromImport

--- a/src/ducktools/pythonfinder/venv.py
+++ b/src/ducktools/pythonfinder/venv.py
@@ -30,7 +30,6 @@ except ImportError:
 import os
 import sys
 
-
 from ducktools.classbuilder.prefab import Prefab, attribute
 from ducktools.lazyimporter import LazyImporter, FromImport, ModuleImport
 

--- a/src/ducktools/pythonfinder/win32/__init__.py
+++ b/src/ducktools/pythonfinder/win32/__init__.py
@@ -22,8 +22,12 @@
 # SOFTWARE.
 from __future__ import annotations
 
-from _collections_abc import Iterator
 import itertools
+
+try:
+    from _collections_abc import Iterator
+except ImportError:
+    from collections.abc import Iterator
 
 from ..shared import PythonInstall, get_uv_pythons, DetailFinder
 from .pyenv_search import get_pyenv_pythons

--- a/src/ducktools/pythonfinder/win32/pyenv_search.py
+++ b/src/ducktools/pythonfinder/win32/pyenv_search.py
@@ -24,7 +24,11 @@ from __future__ import annotations
 
 import os
 import os.path
-from _collections_abc import Iterator
+
+try:
+    from _collections_abc import Iterator
+except ImportError:
+    from collections.abc import Iterator
 
 from ..shared import PythonInstall, DetailFinder
 

--- a/src/ducktools/pythonfinder/win32/registry_search.py
+++ b/src/ducktools/pythonfinder/win32/registry_search.py
@@ -20,7 +20,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from __future__ import annotations
+
+# This is an overly broad ignore as linux mypy errors
+# mypy: disable-error-code="attr-defined"
 
 """
 Search the Windows registry to find python installs
@@ -28,8 +30,10 @@ Search the Windows registry to find python installs
 Based on PEP 514 registry entries.
 """
 
+from __future__ import annotations
+
 import os.path
-import winreg  # noqa  # pycharm seems to think winreg doesn't exist in python3.12
+import winreg
 from _collections_abc import Iterator
 
 from ..shared import DetailFinder, PythonInstall, version_str_to_tuple


### PR DESCRIPTION
This adds "managed_by" values for known macos paths.

Homebrew: `/opt/homebrew` or `/usr/local/opt`
python.org: `/Library/Frameworks/Python.framework`
Xcode: `/Applications/Xcode.app` and `/Library/Developer/CommandLineTools`