### PR TITLE
Fix `--help` in the command line on Python 3.15

### DIFF
--- a/src/ducktools/pythonfinder/__main__.py
+++ b/src/ducktools/pythonfinder/__main__.py
@@ -96,7 +96,7 @@ def _get_parser_class() -> type[argparse.ArgumentParser]:
         This prevents the unnecessary import.
         """
 
-        def _get_formatter(self):
+        def _get_formatter(self, file=None, *args, **kwargs):
             # Calculate width
             try:
                 columns = int(os.environ['COLUMNS'])
@@ -110,7 +110,13 @@ def _get_parser_class() -> type[argparse.ArgumentParser]:
                     columns = size.columns
 
             # noinspection PyArgumentList
-            return self.formatter_class(prog=self.prog, width=columns - 2)
+            formatter = self.formatter_class(prog=self.prog, width=columns - 2)
+            if sys.version_info >= (3, 15):  #
+                formatter._set_color(self.color, file=file)
+            elif sys.version_info >= (3, 14):
+                formatter._set_color(self.color)
+
+            return formatter
 
     return FixedArgumentParser
 

--- a/uv.lock
+++ b/uv.lock
@@ -170,7 +170,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
-zipapp-build = [
+zipapp = [
     { name = "pip" },
 ]
 
@@ -188,7 +188,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-cov", specifier = ">=6.1" },
 ]
-zipapp-build = [{ name = "pip", specifier = ">=26.0" }]
+zipapp = [{ name = "pip", specifier = ">=26.0" }]
 
 [[package]]
 name = "exceptiongroup"


### PR DESCRIPTION
Python 3.15 added an optional argument to `_get_formatter`, this fixes this and the colours.

Unfortunately 3.14 greatly reduced the performance of argparse, but this needs to be fixed in CPython (or I need to switch parser).